### PR TITLE
Implementation of Search field

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -19,6 +19,8 @@ android {
         vectorDrawables {
             useSupportLibrary true
         }
+
+        testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
 
     buildTypes {
@@ -80,4 +82,10 @@ dependencies {
     kapt hiltDependencies.kapt
 
     implementation retrofit.jsonConverter
+
+    testImplementation test.junit
+    testImplementation test.coroutines
+    androidTestImplementation test.androidxJunit
+    androidTestImplementation test.composeJunit4
+    debugImplementation test.composeManifest
 }

--- a/app/src/androidTest/java/SimpleInstrumentationTest.kt
+++ b/app/src/androidTest/java/SimpleInstrumentationTest.kt
@@ -1,0 +1,49 @@
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.hasTestTag
+import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performTextInput
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.youarelaunched.challenge.MainActivity
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class SimpleInstrumentationTest {
+    @get:Rule
+    val composeTestRule = createAndroidComposeRule<MainActivity>()
+
+    @Test
+    fun vendorsListDisplayed() {
+        composeTestRule.onNode(hasTestTag("VENDORS_SEARCH_FIELD_TEST_TAG")).assertIsDisplayed()
+
+        composeTestRule.onNodeWithText("Search…").assertIsDisplayed()
+
+        composeTestRule.onNode(hasTestTag("VENDORS_LIST_TEST_TAG")).assertIsDisplayed()
+    }
+
+    @Test
+    fun emptyScreenDisplayed() {
+        composeTestRule.onNode(hasTestTag("VENDORS_SEARCH_FIELD_TEST_TAG")).performTextInput("test")
+        composeTestRule.onNodeWithContentDescription("Search Icon").performClick()
+
+        composeTestRule.onNodeWithText("Sorry! No results found…").assertIsDisplayed()
+
+        composeTestRule.onNodeWithText("Please try a different search request or browse businesses from the list")
+            .assertIsDisplayed()
+
+        composeTestRule.onNode(hasTestTag("VENDORS_EMPTY_SCREEN_TEST_TAG")).assertIsDisplayed()
+
+    }
+
+    @Test
+    fun searchResultDisplayed() {
+        composeTestRule.onNode(hasTestTag("VENDORS_SEARCH_FIELD_TEST_TAG")).performTextInput("cat")
+        composeTestRule.onNodeWithContentDescription("Search Icon").performClick()
+
+        composeTestRule.onNode(hasTestTag("VENDORS_LIST_TEST_TAG")).assertIsDisplayed()
+    }
+}

--- a/app/src/main/java/com/youarelaunched/challenge/data/network/api/ApiVendors.kt
+++ b/app/src/main/java/com/youarelaunched/challenge/data/network/api/ApiVendors.kt
@@ -4,5 +4,7 @@ import com.youarelaunched.challenge.data.network.models.NetworkVendor
 
 interface ApiVendors {
 
+    suspend fun getVendorsByCompanyName(companyName: String): List<NetworkVendor>
+
     suspend fun getVendors(): List<NetworkVendor>
 }

--- a/app/src/main/java/com/youarelaunched/challenge/data/network/api/NetworkDataProvider.kt
+++ b/app/src/main/java/com/youarelaunched/challenge/data/network/api/NetworkDataProvider.kt
@@ -14,6 +14,23 @@ class NetworkDataProvider @Inject constructor(
     @DispatcherIo private val workDispatcher: CoroutineDispatcher,
     @ApplicationContext private val appContext: Context
 ) : ApiVendors {
+    override suspend fun getVendorsByCompanyName(companyName: String): List<NetworkVendor> =
+        withContext(workDispatcher) {
+            val json = appContext.assets
+                .open("vendors.json")
+                .bufferedReader()
+                .use {
+                    it.readText()
+                }
+
+            Gson()
+                .fromJson(json, NetworkVendorsData::class.java)
+                .vendors
+                .filter { vendor ->
+                    vendor.companyName.lowercase()
+                        .contains(companyName.lowercase(), ignoreCase = true)
+                }
+        }
 
     override suspend fun getVendors(): List<NetworkVendor> = withContext(workDispatcher) {
         val json = appContext.assets

--- a/app/src/main/java/com/youarelaunched/challenge/data/repository/VendorsRepository.kt
+++ b/app/src/main/java/com/youarelaunched/challenge/data/repository/VendorsRepository.kt
@@ -4,5 +4,6 @@ import com.youarelaunched.challenge.data.repository.model.Vendor
 
 interface VendorsRepository {
 
+    suspend fun getVendorsByCompanyName(companyName: String): List<Vendor>
     suspend fun getVendors(): List<Vendor>
 }

--- a/app/src/main/java/com/youarelaunched/challenge/data/repository/VendorsRepositoryImpl.kt
+++ b/app/src/main/java/com/youarelaunched/challenge/data/repository/VendorsRepositoryImpl.kt
@@ -14,6 +14,12 @@ class VendorsRepositoryImpl @Inject constructor(
     @DispatcherIo private val workDispatcher: CoroutineDispatcher,
     private val api: ApiVendors
 ) : VendorsRepository {
+    override suspend fun getVendorsByCompanyName(companyName: String): List<Vendor> =
+        withContext(workDispatcher) {
+            api.getVendorsByCompanyName(companyName).map {
+                it.toVendor()
+            }
+        }
 
     override suspend fun getVendors(): List<Vendor> = withContext(workDispatcher) {
         api.getVendors().map {

--- a/app/src/main/java/com/youarelaunched/challenge/ui/screen/view/VendorsScreen.kt
+++ b/app/src/main/java/com/youarelaunched/challenge/ui/screen/view/VendorsScreen.kt
@@ -16,6 +16,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import com.youarelaunched.challenge.ui.screen.state.VendorsScreenUiState
 import com.youarelaunched.challenge.ui.screen.view.components.ChatsumerSnackbar
+import com.youarelaunched.challenge.ui.screen.view.components.EmptySearchResult
 import com.youarelaunched.challenge.ui.screen.view.components.SearchField
 import com.youarelaunched.challenge.ui.screen.view.components.VendorItem
 import com.youarelaunched.challenge.ui.theme.VendorAppTheme
@@ -25,13 +26,22 @@ fun VendorsRoute(
     viewModel: VendorsVM
 ) {
     val uiState by viewModel.uiState.collectAsState()
+    val searchText by viewModel.searchText.collectAsState()
 
-    VendorsScreen(uiState = uiState)
+    VendorsScreen(
+        uiState = uiState,
+        searchText = searchText,
+        onTextChange = viewModel::onTextChange,
+        performSearch = viewModel::getVendors
+    )
 }
 
 @Composable
 fun VendorsScreen(
-    uiState: VendorsScreenUiState
+    uiState: VendorsScreenUiState,
+    searchText: String,
+    onTextChange: (String) -> Unit,
+    performSearch: () -> Unit
 ) {
     Scaffold(
         modifier = Modifier.fillMaxSize(),
@@ -41,7 +51,11 @@ fun VendorsScreen(
         Column(
             modifier = Modifier.fillMaxWidth()
         ) {
-            SearchField()
+            SearchField(
+                searchText = searchText,
+                onTextChange = onTextChange,
+                performSearch = performSearch
+            )
             if (!uiState.vendors.isNullOrEmpty()) {
                 LazyColumn(
                     modifier = Modifier
@@ -58,8 +72,9 @@ fun VendorsScreen(
                             vendor = vendor
                         )
                     }
-
                 }
+            } else if (uiState.vendors != null && uiState.vendors.isEmpty()) {
+                EmptySearchResult()
             }
         }
     }

--- a/app/src/main/java/com/youarelaunched/challenge/ui/screen/view/VendorsScreen.kt
+++ b/app/src/main/java/com/youarelaunched/challenge/ui/screen/view/VendorsScreen.kt
@@ -13,6 +13,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.unit.dp
 import com.youarelaunched.challenge.ui.screen.state.VendorsScreenUiState
 import com.youarelaunched.challenge.ui.screen.view.components.ChatsumerSnackbar
@@ -43,8 +44,12 @@ fun VendorsScreen(
     onTextChange: (String) -> Unit,
     performSearch: () -> Unit
 ) {
+//    val lazyListState = rememberLazyListState()
+//    lazyListState.firstVisibleItemIndex>0|| lazyListState.firstVisibleItemScrollOffset>0
     Scaffold(
-        modifier = Modifier.fillMaxSize(),
+        modifier = Modifier
+            .fillMaxSize()
+            .testTag("VENDORS_LIST_TEST_TAG"),
         backgroundColor = VendorAppTheme.colors.background,
         snackbarHost = { ChatsumerSnackbar(it) }
     ) { paddings ->

--- a/app/src/main/java/com/youarelaunched/challenge/ui/screen/view/VendorsScreen.kt
+++ b/app/src/main/java/com/youarelaunched/challenge/ui/screen/view/VendorsScreen.kt
@@ -12,11 +12,16 @@ import androidx.compose.material.Scaffold
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.zIndex
 import com.youarelaunched.challenge.ui.screen.state.VendorsScreenUiState
 import com.youarelaunched.challenge.ui.screen.view.components.ChatsumerSnackbar
+import com.youarelaunched.challenge.ui.screen.view.components.CoordinatedScroll
 import com.youarelaunched.challenge.ui.screen.view.components.EmptySearchResult
 import com.youarelaunched.challenge.ui.screen.view.components.SearchField
 import com.youarelaunched.challenge.ui.screen.view.components.VendorItem
@@ -44,8 +49,8 @@ fun VendorsScreen(
     onTextChange: (String) -> Unit,
     performSearch: () -> Unit
 ) {
-//    val lazyListState = rememberLazyListState()
-//    lazyListState.firstVisibleItemIndex>0|| lazyListState.firstVisibleItemScrollOffset>0
+    val toolbarHeightPx = remember { mutableStateOf(0f) }
+    val topPanelOffset = remember { mutableStateOf(0f) }
     Scaffold(
         modifier = Modifier
             .fillMaxSize()
@@ -53,33 +58,51 @@ fun VendorsScreen(
         backgroundColor = VendorAppTheme.colors.background,
         snackbarHost = { ChatsumerSnackbar(it) }
     ) { paddings ->
-        Column(
-            modifier = Modifier.fillMaxWidth()
-        ) {
-            SearchField(
-                searchText = searchText,
-                onTextChange = onTextChange,
-                performSearch = performSearch
-            )
-            if (!uiState.vendors.isNullOrEmpty()) {
-                LazyColumn(
+
+        CoordinatedScroll(
+            collapsingAreaHeightPx = toolbarHeightPx
+        ) { offset, nestedScroll ->
+            topPanelOffset.value = offset
+
+            Column(
+                Modifier
+                    .fillMaxSize()
+                    .nestedScroll(nestedScroll)
+            ) {
+                SearchField(
+                    currentOffset = offset,
+                    maxOffset = toolbarHeightPx.value,
                     modifier = Modifier
-                        .padding(paddings)
-                        .fillMaxSize(),
-                    verticalArrangement = Arrangement.spacedBy(16.dp),
-                    contentPadding = PaddingValues(
-                        vertical = 24.dp,
-                        horizontal = 16.dp
-                    )
-                ) {
-                    items(uiState.vendors) { vendor ->
-                        VendorItem(
-                            vendor = vendor
+                        .zIndex(1f)
+                        .fillMaxWidth(),
+                    onHeightCalculated = {
+                        toolbarHeightPx.value = it
+                    },
+                    searchText = searchText,
+                    onTextChange = onTextChange,
+                    performSearch = performSearch
+                )
+
+                if (!uiState.vendors.isNullOrEmpty()) {
+                    LazyColumn(
+                        modifier = Modifier
+                            .padding(paddings)
+                            .fillMaxSize(),
+                        verticalArrangement = Arrangement.spacedBy(16.dp),
+                        contentPadding = PaddingValues(
+                            vertical = 24.dp,
+                            horizontal = 16.dp
                         )
+                    ) {
+                        items(uiState.vendors) { vendor ->
+                            VendorItem(
+                                vendor = vendor
+                            )
+                        }
                     }
+                } else if (uiState.vendors != null && uiState.vendors.isEmpty()) {
+                    EmptySearchResult()
                 }
-            } else if (uiState.vendors != null && uiState.vendors.isEmpty()) {
-                EmptySearchResult()
             }
         }
     }

--- a/app/src/main/java/com/youarelaunched/challenge/ui/screen/view/VendorsScreen.kt
+++ b/app/src/main/java/com/youarelaunched/challenge/ui/screen/view/VendorsScreen.kt
@@ -1,8 +1,10 @@
 package com.youarelaunched.challenge.ui.screen.view
 
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
@@ -14,6 +16,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import com.youarelaunched.challenge.ui.screen.state.VendorsScreenUiState
 import com.youarelaunched.challenge.ui.screen.view.components.ChatsumerSnackbar
+import com.youarelaunched.challenge.ui.screen.view.components.SearchField
 import com.youarelaunched.challenge.ui.screen.view.components.VendorItem
 import com.youarelaunched.challenge.ui.theme.VendorAppTheme
 
@@ -35,23 +38,28 @@ fun VendorsScreen(
         backgroundColor = VendorAppTheme.colors.background,
         snackbarHost = { ChatsumerSnackbar(it) }
     ) { paddings ->
-        if (!uiState.vendors.isNullOrEmpty()) {
-            LazyColumn(
-                modifier = Modifier
-                    .padding(paddings)
-                    .fillMaxSize(),
-                verticalArrangement = Arrangement.spacedBy(16.dp),
-                contentPadding = PaddingValues(
-                    vertical = 24.dp,
-                    horizontal = 16.dp
-                )
-            ) {
-                items(uiState.vendors) { vendor ->
-                    VendorItem(
-                        vendor = vendor
+        Column(
+            modifier = Modifier.fillMaxWidth()
+        ) {
+            SearchField()
+            if (!uiState.vendors.isNullOrEmpty()) {
+                LazyColumn(
+                    modifier = Modifier
+                        .padding(paddings)
+                        .fillMaxSize(),
+                    verticalArrangement = Arrangement.spacedBy(16.dp),
+                    contentPadding = PaddingValues(
+                        vertical = 24.dp,
+                        horizontal = 16.dp
                     )
-                }
+                ) {
+                    items(uiState.vendors) { vendor ->
+                        VendorItem(
+                            vendor = vendor
+                        )
+                    }
 
+                }
             }
         }
     }

--- a/app/src/main/java/com/youarelaunched/challenge/ui/screen/view/VendorsVM.kt
+++ b/app/src/main/java/com/youarelaunched/challenge/ui/screen/view/VendorsVM.kt
@@ -3,10 +3,16 @@ package com.youarelaunched.challenge.ui.screen.view
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.youarelaunched.challenge.data.repository.VendorsRepository
+import com.youarelaunched.challenge.data.repository.model.Vendor
 import com.youarelaunched.challenge.ui.screen.state.VendorsScreenUiState
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.debounce
+import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import javax.inject.Inject
@@ -16,12 +22,41 @@ class VendorsVM @Inject constructor(
     private val repository: VendorsRepository
 ) : ViewModel() {
 
+    private val _searchText = MutableStateFlow("")
+    val searchText = _searchText.asStateFlow()
+
     private val _uiState = MutableStateFlow(
         VendorsScreenUiState(
             vendors = null
         )
     )
-    val uiState = _uiState.asStateFlow()
+
+    suspend fun fetchVendors(): List<Vendor> {
+        return if (searchText.value.isNotEmpty())
+            repository.getVendorsByCompanyName(searchText.value)
+        else
+            repository.getVendors()
+    }
+
+    @OptIn(FlowPreview::class)
+    val uiState = _uiState.debounce(500L)
+        .combine(searchText) { vendors, searchText ->
+            if (searchText.isBlank()) {
+                vendors
+            } else if (searchText.length < 3) {
+                vendors
+            } else {
+                VendorsScreenUiState(
+                    fetchVendors()
+                )
+            }
+        }.stateIn(
+            viewModelScope,
+            SharingStarted.WhileSubscribed(5000),
+            VendorsScreenUiState(
+                vendors = _uiState.value.vendors
+            )
+        )
 
     init {
         getVendors()
@@ -31,10 +66,13 @@ class VendorsVM @Inject constructor(
         viewModelScope.launch {
             _uiState.update {
                 it.copy(
-                    vendors = repository.getVendors()
+                    vendors = fetchVendors()
                 )
             }
         }
     }
 
+    fun onTextChange(text: String) {
+        _searchText.value = text
+    }
 }

--- a/app/src/main/java/com/youarelaunched/challenge/ui/screen/view/components/EmptySearchResult.kt
+++ b/app/src/main/java/com/youarelaunched/challenge/ui/screen/view/components/EmptySearchResult.kt
@@ -1,0 +1,48 @@
+package com.youarelaunched.challenge.ui.screen.view.components
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import com.youarelaunched.challenge.middle.R
+import com.youarelaunched.challenge.ui.theme.VendorAppTheme
+
+@Composable
+fun EmptySearchResult() {
+    Box(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(horizontal = 24.dp),
+        contentAlignment = Alignment.Center
+    ) {
+        Column {
+            Text(
+                modifier = Modifier.fillMaxWidth(),
+                text = stringResource(id = R.string.msg_no_result_search),
+                style = VendorAppTheme.typography.h2,
+                textAlign = TextAlign.Center,
+                color = VendorAppTheme.colors.textDarkGreen,
+            )
+
+            Spacer(modifier = Modifier.height(8.dp))
+
+            Text(
+                modifier = Modifier.fillMaxWidth(),
+                text = stringResource(id = R.string.msg_no_result_search_hint_to_fix),
+                style = VendorAppTheme.typography.subtitle1,
+                textAlign = TextAlign.Center,
+                color = VendorAppTheme.colors.textDark,
+            )
+        }
+    }
+}

--- a/app/src/main/java/com/youarelaunched/challenge/ui/screen/view/components/EmptySearchResult.kt
+++ b/app/src/main/java/com/youarelaunched/challenge/ui/screen/view/components/EmptySearchResult.kt
@@ -11,6 +11,7 @@ import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
@@ -22,7 +23,8 @@ fun EmptySearchResult() {
     Box(
         modifier = Modifier
             .fillMaxSize()
-            .padding(horizontal = 24.dp),
+            .padding(horizontal = 24.dp)
+            .testTag("VENDORS_EMPTY_SCREEN_TEST_TAG"),
         contentAlignment = Alignment.Center
     ) {
         Column {

--- a/app/src/main/java/com/youarelaunched/challenge/ui/screen/view/components/SearchField.kt
+++ b/app/src/main/java/com/youarelaunched/challenge/ui/screen/view/components/SearchField.kt
@@ -7,6 +7,7 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.BottomNavigationDefaults.Elevation
 import androidx.compose.material.Icon
+import androidx.compose.material.IconButton
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Surface
 import androidx.compose.material.Text
@@ -22,7 +23,11 @@ import com.youarelaunched.challenge.middle.R
 import com.youarelaunched.challenge.ui.theme.VendorAppTheme
 
 @Composable
-fun SearchField() {
+fun SearchField(
+    searchText: String,
+    onTextChange: (String) -> Unit,
+    performSearch: () -> Unit,
+) {
     Surface(
         modifier = Modifier
             .fillMaxWidth()
@@ -32,20 +37,21 @@ fun SearchField() {
         shape = RoundedCornerShape(size = 16.dp),
     ) {
         TextField(
-            value = "",
-            onValueChange = {},
+            value = searchText,
+            onValueChange = onTextChange,
             modifier = Modifier
                 .fillMaxWidth()
                 .height(height = 52.dp),
-            textStyle = MaterialTheme.typography.h2,
+            textStyle = MaterialTheme.typography.subtitle1,
             trailingIcon = {
-                Icon(
-                    contentDescription = "Search Icon",
-                    painter = painterResource(id = R.drawable.ic_search),
-                    modifier = Modifier.size(24.dp),
-                    tint = VendorAppTheme.colors.text
-
-                )
+                IconButton(onClick = performSearch) {
+                    Icon(
+                        contentDescription = "Search Icon",
+                        painter = painterResource(id = R.drawable.ic_search),
+                        modifier = Modifier.size(24.dp),
+                        tint = VendorAppTheme.colors.text
+                    )
+                }
             },
             placeholder = {
                 Text(

--- a/app/src/main/java/com/youarelaunched/challenge/ui/screen/view/components/SearchField.kt
+++ b/app/src/main/java/com/youarelaunched/challenge/ui/screen/view/components/SearchField.kt
@@ -1,0 +1,68 @@
+package com.youarelaunched.challenge.ui.screen.view.components
+
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.BottomNavigationDefaults.Elevation
+import androidx.compose.material.Icon
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.Surface
+import androidx.compose.material.Text
+import androidx.compose.material.TextField
+import androidx.compose.material.TextFieldDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import com.youarelaunched.challenge.middle.R
+import com.youarelaunched.challenge.ui.theme.VendorAppTheme
+
+@Composable
+fun SearchField() {
+    Surface(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(top = 24.dp, start = 12.dp, end = 12.dp),
+        elevation = Elevation,
+        color = VendorAppTheme.colors.background,
+        shape = RoundedCornerShape(size = 16.dp),
+    ) {
+        TextField(
+            value = "",
+            onValueChange = {},
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(height = 52.dp),
+            textStyle = MaterialTheme.typography.h2,
+            trailingIcon = {
+                Icon(
+                    contentDescription = "Search Icon",
+                    painter = painterResource(id = R.drawable.ic_search),
+                    modifier = Modifier.size(24.dp),
+                    tint = VendorAppTheme.colors.text
+
+                )
+            },
+            placeholder = {
+                Text(
+                    text = stringResource(id = R.string.msg_search_field_hint),
+                    color = VendorAppTheme.colors.text,
+                    style = VendorAppTheme.typography.subtitle2
+                )
+            },
+            colors = TextFieldDefaults.textFieldColors(
+                textColor = VendorAppTheme.colors.text,
+                backgroundColor = VendorAppTheme.colors.background,
+                disabledIndicatorColor = Color.Transparent,
+                focusedIndicatorColor = Color.Transparent,
+                unfocusedIndicatorColor = Color.Transparent,
+                disabledTextColor = Color.Transparent
+            ),
+            singleLine = true,
+        )
+    }
+}

--- a/app/src/main/java/com/youarelaunched/challenge/ui/screen/view/components/SearchField.kt
+++ b/app/src/main/java/com/youarelaunched/challenge/ui/screen/view/components/SearchField.kt
@@ -2,6 +2,7 @@ package com.youarelaunched.challenge.ui.screen.view.components
 
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -14,25 +15,45 @@ import androidx.compose.material.Text
 import androidx.compose.material.TextField
 import androidx.compose.material.TextFieldDefaults
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.MutableState
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.alpha
+import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.input.nestedscroll.NestedScrollConnection
+import androidx.compose.ui.input.nestedscroll.NestedScrollSource
+import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.dp
 import com.youarelaunched.challenge.middle.R
 import com.youarelaunched.challenge.ui.theme.VendorAppTheme
+import kotlin.math.pow
+import kotlin.math.roundToInt
 
 @Composable
 fun SearchField(
+    currentOffset: Float,
+    maxOffset: Float,
+    modifier: Modifier = Modifier,
+    onHeightCalculated: (Float) -> Unit,
     searchText: String,
     onTextChange: (String) -> Unit,
     performSearch: () -> Unit,
 ) {
+
+    val alpha = (kotlin.math.abs(currentOffset) / maxOffset).pow(0.75f)
     Surface(
-        modifier = Modifier
-            .fillMaxWidth()
-            .padding(top = 24.dp, start = 12.dp, end = 12.dp),
+        modifier = modifier
+            .offset { IntOffset(x = 0, y = currentOffset.roundToInt()) }
+            .padding(top = 24.dp, start = 12.dp, end = 12.dp)
+            .onGloballyPositioned {
+                onHeightCalculated(it.size.height.toFloat() + 100f)
+            },
         elevation = Elevation,
         color = VendorAppTheme.colors.background,
         shape = RoundedCornerShape(size = 16.dp),
@@ -41,6 +62,7 @@ fun SearchField(
             value = searchText,
             onValueChange = onTextChange,
             modifier = Modifier
+                .alpha(1f - alpha)
                 .fillMaxWidth()
                 .height(height = 52.dp)
                 .testTag("VENDORS_SEARCH_FIELD_TEST_TAG"),
@@ -73,4 +95,41 @@ fun SearchField(
             singleLine = true,
         )
     }
+}
+
+
+@Composable
+internal fun CoordinatedScroll(
+    collapsingAreaHeightPx: MutableState<Float> = remember { mutableStateOf(0f) },
+    content: @Composable (Float, NestedScrollConnection) -> Unit
+) {
+    val toolbarOffsetHeightPx = remember { mutableStateOf(0f) }
+    val currentAbsoluteOffsetPx = remember { mutableStateOf(0f) }
+
+    val nestedScrollConnection = remember {
+        object : NestedScrollConnection {
+            override fun onPreScroll(available: Offset, source: NestedScrollSource): Offset {
+                val delta = available.y
+
+                var absoluteOffset = currentAbsoluteOffsetPx.value + delta
+                if (absoluteOffset > 0f) {
+                    absoluteOffset = 0f
+                }
+                currentAbsoluteOffsetPx.value = absoluteOffset
+
+                if (absoluteOffset >= -collapsingAreaHeightPx.value) {
+                    toolbarOffsetHeightPx.value = absoluteOffset
+                } else {
+                    toolbarOffsetHeightPx.value = -collapsingAreaHeightPx.value
+                }
+
+                return Offset.Zero
+            }
+        }
+    }
+
+    content(
+        toolbarOffsetHeightPx.value,
+        nestedScrollConnection
+    )
 }

--- a/app/src/main/java/com/youarelaunched/challenge/ui/screen/view/components/SearchField.kt
+++ b/app/src/main/java/com/youarelaunched/challenge/ui/screen/view/components/SearchField.kt
@@ -16,6 +16,7 @@ import androidx.compose.material.TextFieldDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
@@ -41,7 +42,8 @@ fun SearchField(
             onValueChange = onTextChange,
             modifier = Modifier
                 .fillMaxWidth()
-                .height(height = 52.dp),
+                .height(height = 52.dp)
+                .testTag("VENDORS_SEARCH_FIELD_TEST_TAG"),
             textStyle = MaterialTheme.typography.subtitle1,
             trailingIcon = {
                 IconButton(onClick = performSearch) {

--- a/app/src/main/java/com/youarelaunched/challenge/ui/theme/Color.kt
+++ b/app/src/main/java/com/youarelaunched/challenge/ui/theme/Color.kt
@@ -12,11 +12,13 @@ private val GrayPrimary = Color(0xFF575757)
 private val GraySecondary = Color(0xFF949494)
 private val Background = Color(0xFFFCFCFC)
 private val Green = Color(0xFF55C595)
+private val DarkGreen = Color(0xFF289460)
 
 val LightColorsPalette = VendorAppColors(
     text = GraySecondary,
     textDark = GrayPrimary,
     textLight = Color.White,
+    textDarkGreen = DarkGreen,
     buttonSelected = Green,
     buttonUnselected = Color.White,
     background = Background,
@@ -29,6 +31,7 @@ data class VendorAppColors(
     val text: Color,
     val textDark: Color,
     val textLight: Color,
+    val textDarkGreen: Color,
 
     val buttonSelected: Color,
     val buttonUnselected: Color,

--- a/app/src/main/res/drawable/ic_search.xml
+++ b/app/src/main/res/drawable/ic_search.xml
@@ -1,0 +1,29 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+  <path
+      android:pathData="M11,11m-7,0a7,7 0,1 1,14 0a7,7 0,1 1,-14 0"
+      android:strokeAlpha="0.3"
+      android:strokeWidth="2"
+      android:fillColor="#00000000"
+      android:strokeColor="#949494"
+      android:fillAlpha="0.3"/>
+  <path
+      android:pathData="M11,8C10.606,8 10.216,8.078 9.852,8.228C9.488,8.379 9.157,8.6 8.879,8.879C8.6,9.157 8.379,9.488 8.228,9.852C8.078,10.216 8,10.606 8,11"
+      android:strokeAlpha="0.3"
+      android:strokeWidth="2"
+      android:fillColor="#00000000"
+      android:strokeColor="#949494"
+      android:fillAlpha="0.3"
+      android:strokeLineCap="round"/>
+  <path
+      android:pathData="M20,20L17,17"
+      android:strokeAlpha="0.3"
+      android:strokeWidth="2"
+      android:fillColor="#00000000"
+      android:strokeColor="#949494"
+      android:fillAlpha="0.3"
+      android:strokeLineCap="round"/>
+</vector>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -2,4 +2,8 @@
     <string name="app_name">JuniorSolution</string>
     <string name="msg_error_no_internet">No Internet connection. Connect to the Internet and try again.</string>
     <string name="msg_unknown_error">Error: %s </string>
+    <string name="msg_search_field_hint">Search…</string>
+    <string name="msg_no_result_search">Sorry! No results found…</string>
+    <string name="msg_no_result_search_hint_to_fix">Please try a different search request or browse businesses from the list</string>
+
 </resources>

--- a/app/src/test/java/SimpleTest.kt
+++ b/app/src/test/java/SimpleTest.kt
@@ -1,0 +1,116 @@
+import com.youarelaunched.challenge.data.repository.VendorsRepository
+import com.youarelaunched.challenge.data.repository.model.Vendor
+import com.youarelaunched.challenge.ui.screen.view.VendorsVM
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.TestCoroutineScope
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.Assert
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TestWatcher
+import org.junit.runner.Description
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+
+@RunWith(JUnit4::class)
+@OptIn(ExperimentalCoroutinesApi::class)
+class SimpleTest {
+
+    @get:Rule
+    val mainDispatcherRule = MainCoroutineRule()
+
+    @Test
+    fun `Vendor Response Successful`() = runBlocking {
+        val viewModel = VendorsVM(MockData())
+        Assert.assertEquals(viewModel.fetchVendors().isNotEmpty(), true)
+        Assert.assertEquals(viewModel.fetchVendors()[0].companyName, "testName")
+        Assert.assertEquals(viewModel.fetchVendors()[0].coverPhoto, "testPhoto")
+        Assert.assertEquals(viewModel.fetchVendors()[0].area, "testArea")
+        Assert.assertEquals(viewModel.fetchVendors()[0].tags, "testTag")
+    }
+
+    @Test
+    fun `Vendor Response By Company Name Successful`() = runBlocking {
+        val viewModel = VendorsVM(MockData())
+        viewModel.onTextChange("testNameByName")
+        Assert.assertEquals(viewModel.fetchVendors().isNotEmpty(), true)
+        Assert.assertEquals(viewModel.fetchVendors()[0].companyName, "testNameByName")
+        Assert.assertEquals(viewModel.fetchVendors()[0].coverPhoto, "testPhotoByName")
+        Assert.assertEquals(viewModel.fetchVendors()[0].area, "testAreaByName")
+        Assert.assertEquals(viewModel.fetchVendors()[0].tags, "testTagByName")
+    }
+
+    //if Vendor Response By Company Name  Empty we will show the vendors list
+    @Test
+    fun `Vendor Response By Company Name  Empty`() = runTest {
+        val viewModel = VendorsVM(MockData())
+        viewModel.onTextChange("")
+        Assert.assertEquals(viewModel.fetchVendors().isNotEmpty(), true)
+        Assert.assertEquals(viewModel.fetchVendors()[0].companyName, "testName")
+        Assert.assertEquals(viewModel.fetchVendors()[0].coverPhoto, "testPhoto")
+        Assert.assertEquals(viewModel.fetchVendors()[0].area, "testArea")
+        Assert.assertEquals(viewModel.fetchVendors()[0].tags, "testTag")
+    }
+}
+
+class MockData : VendorsRepository {
+
+    override suspend fun getVendorsByCompanyName(companyName: String): List<Vendor> {
+        return listOf(
+            Vendor(
+                id = 1,
+                companyName = "testNameByName",
+                coverPhoto = "testPhotoByName",
+                area = "testAreaByName",
+                favorite = true,
+                categories = null,
+                tags = "testTagByName"
+            ),
+            Vendor(
+                id = 2,
+                companyName = "testNameByName2",
+                coverPhoto = "testPhotoByName2",
+                area = "testAreaByName2",
+                favorite = true,
+                categories = null,
+                tags = "testTagByName2"
+            )
+        )
+    }
+
+    override suspend fun getVendors(): List<Vendor> {
+        return listOf(
+            Vendor(
+                id = 1,
+                companyName = "testName",
+                coverPhoto = "testPhoto",
+                area = "testArea",
+                favorite = true,
+                categories = null,
+                tags = "testTag"
+            )
+        )
+    }
+}
+
+@ExperimentalCoroutinesApi
+class MainCoroutineRule(
+    private val dispatcher: CoroutineDispatcher = StandardTestDispatcher()
+) : TestWatcher(), TestCoroutineScope by TestCoroutineScope(dispatcher) {
+
+    override fun starting(description: Description) {
+        super.starting(description)
+        Dispatchers.setMain(dispatcher)
+    }
+
+    override fun finished(description: Description) {
+        super.finished(description)
+        Dispatchers.resetMain()
+    }
+}

--- a/build.gradle
+++ b/build.gradle
@@ -69,6 +69,14 @@ buildscript {
                 lib          : "com.squareup.retrofit2:retrofit:$retrofitVersion",
                 jsonConverter: "com.squareup.retrofit2:converter-gson:$retrofitVersion"
         ]
+
+        test = [
+                junit:           'junit:junit:4.13.2',
+                androidxJunit:   'androidx.test.ext:junit:1.1.3',
+                coroutines:      'org.jetbrains.kotlinx:kotlinx-coroutines-test:1.6.4',
+                composeJunit4:   'androidx.compose.ui:ui-test-junit4:1.3.2',
+                composeManifest: 'androidx.compose.ui:ui-test-manifest:1.3.2'
+        ]
     }
 
     dependencies {


### PR DESCRIPTION
**Part 1**
Add a Search field according to the design.
Add a "No result" item. It should be visible if the vendor's list is empty.

**Part 2**
Collect a query parameter from the Search field when a user presses on the search icon
Extend UI and business logic to perform getVendors() call with a collected query parameter
Use a query to filter data from the ApiVedors by the company_name field
Nice to have: start search automatically after a user has typed 3 symbols with 0.5s debouncing

**Part 3**
Cover the getVendors() method in the VendorsVM by Unit Tests for the following cases:
Data was loaded successfully and the list contains at least one item
Data loaded with error

**Cover the VendorsScreen by Integration (UI) Tests for the following cases:**
"No result" item visible if the vendor's list is empty
At least one item in the vendor's list is displayed if the vendor's list is not empty
![video](https://github.com/urlaunched-com/AndroidMiddleTestTask/assets/38313181/544ade7b-50a7-4667-a53a-6f33b0696b0c)

